### PR TITLE
Add support for apostrophes in the question

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-kerb",
   "description": "A Hubot script to check what's on KERB",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Altmetric <infrastructure@altmetric.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",

--- a/src/kerb.coffee
+++ b/src/kerb.coffee
@@ -25,10 +25,10 @@ chrono = require 'chrono-node'
 kerbUrl = process.env.KERB_URL or 'http://www.kerbfood.com/kings-cross/'
 
 module.exports = (robot) ->
-  robot.respond /what'?s on kerb\??$/i, (res) ->
+  robot.respond /what['’]?s on kerb\??$/i, (res) ->
     tradersForDate(new Date(), res)
 
-  robot.respond /what'?s on kerb (.+)\??/i, (res) ->
+  robot.respond /what['’]?s on kerb (.+)\??/i, (res) ->
     date = chrono.parseDate(res.match[1])
 
     if date

--- a/test/kerb-test.coffee
+++ b/test/kerb-test.coffee
@@ -6,13 +6,8 @@ expect = require('chai').expect
 
 helper = new Helper('../src/kerb.coffee')
 
-describe 'codenames', ->
+describe 'kerb', ->
   beforeEach ->
-    nock('http://codenames.clivemurray.com')
-      .get('/data/prefixes.json')
-      .reply(200, [{title: 'black', attributes: ['colour']}])
-      .get('/data/animals.json')
-      .reply(200, [{title: 'bat', attributes: ['air', 'mammal']}])
     @room = helper.createRoom(httpd: false)
 
   afterEach ->

--- a/test/kerb-test.coffee
+++ b/test/kerb-test.coffee
@@ -64,11 +64,11 @@ describe 'kerb', ->
         .get('/kings-cross/')
         .reply(200, fs.readFileSync(path.join(__dirname, '/fixtures/kings-cross.html')))
 
-      @room.user.say 'alice', 'hubot whats on kerb on 2015-10-28?'
+      @room.user.say 'alice', 'hubot what’s on kerb on 2015-10-28?'
       setTimeout done, 100
 
     it 'responds with the traders for that date', ->
       expect(@room.messages).to.eql [
-        ['alice', 'hubot whats on kerb on 2015-10-28?'],
+        ['alice', 'hubot what’s on kerb on 2015-10-28?'],
         ['hubot', 'Luardos (http://www.kerbfood.com/traders/luardos/)\n  The original burrito boy. Deep in the game, ain\'t coming out any time soon.\nStakehaus (http://www.kerbfood.com/traders/stakehaus/)\n  Home to great steaks\nVinn Goute - Seychelles Kitchen (http://www.kerbfood.com/traders/vinn-goute/)\n  Never had Seychelles cooking before? You\'re in for a treat.\nWell Kneaded (http://www.kerbfood.com/traders/well-kneaded/)\n  Pizza wagon on a mission']
       ]


### PR DESCRIPTION
As Slack automatically converts single quotes (') to apostrophes (’), we need to adjust the pattern matching to support both formats.
